### PR TITLE
Wizard translation updates

### DIFF
--- a/dist/cui-i18n/angular-translate/locale-en_US.json
+++ b/dist/cui-i18n/angular-translate/locale-en_US.json
@@ -1,7 +1,7 @@
 {
-    "cui-org-info": "Organization info",
-    "cui-sign-on-info": "Sign on info",
-    "cui-user-info": "User info",
+    "cui-org-info": "Organization information",
+    "cui-sign-on-info": "Sign on information",
+    "cui-user-info": "User information",
     "cui-preferences": "Preferences",
     "cui-review": "Review",
     "cui-org": "Organization",


### PR DESCRIPTION
@RicardoAlmeidaMarques Please review my changes when you get a second. Per the Covisint UX team, I've:
- created separate translations for organization address and user address (I only took care of English. Hungarian wasn't an option)
- spelled out the word 'information' in place of the abbreviated 'info'
